### PR TITLE
Player und Podcast-Komponenten tauschen sich nun in beide Richtungen aus

### DIFF
--- a/src/app/pages/podcast-episodes/podcast-episodes.component.ts
+++ b/src/app/pages/podcast-episodes/podcast-episodes.component.ts
@@ -8,6 +8,7 @@ import { CloudService } from "../../services/cloud.service";
 import { StreamState } from "../../interfaces/stream-state";
 import * as xml2js from 'xml2js';
 import { CurrentTrackService } from 'src/app/services/current-track.service';
+import { Subscription } from "rxjs";
 
 @Component({
   selector: 'app-podcast-episodes',
@@ -23,6 +24,7 @@ export class PodcastEpisodesComponent implements OnInit {
   apiUrl = environment.apiUrl;
   podcastID : string = "";
   podcast:any;
+  subscription: Subscription | undefined;
 
   constructor(
     private podcastSvc: PodcastepisodesService,
@@ -31,6 +33,15 @@ export class PodcastEpisodesComponent implements OnInit {
   ) { }
 
   ngOnInit() {
+    this.subscription = this.currentTrackService.currentFileAndIndex.subscribe((message: string) => {
+      if (message == '') {
+        return; // Ignore empty initial message
+      }
+      let parts = message.split("_");
+      let action = parts[1];
+      this.play = (action == "stopped");
+      this.pause = !this.play;
+    });
 
     this.route.params.subscribe( p => this.podcastID = p['id'] );
 
@@ -42,12 +53,10 @@ export class PodcastEpisodesComponent implements OnInit {
   }
 
   togglePlayPause() {
-    this.play = !this.play;
-    this.pause = !this.pause;
     if (this.play) {
-      this.currentTrackService.changeTrack(this.podcastID + "_stopped");
+      this.currentTrackService.changeTrack("#" + this.podcastID + "_started");
     } else {
-      this.currentTrackService.changeTrack(this.podcastID + "_started");
+      this.currentTrackService.changeTrack("#" + this.podcastID + "_stopped");
     }
   }
 }

--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -21,8 +21,8 @@
   <!-- PODCAST LIST COLLAPSIBLE -->
   <ul *ngIf="ShowPodcastList" [ngClass]="{'background-color': ListColor}" [ngClass]="{'animation': slideListInOut}"  class="podcast_track_list">
     <!-- <div class="toggle_list" id="close_list" (click)="ShowPodcastList=true">close</div> -->
-    <div *ngFor="let file of files; let i = index" (click)="openFile(file, i)" class='player-controls play'
-      id='podcast_list_object_{{file.episode}}'>
+    <div *ngFor="let file of files; let i = index" (click)="openFileByUpdatingService(file, i)" class='player-controls play'
+         id='podcast_list_object_{{file.episode}}'>
       <span class='track_name podcast_play_pause_icon'>
         <img src="/assets/logos/2070_button_play.png" class="play_pause_symbol">
       </span>


### PR DESCRIPTION
Please note:
Every action (play, pause) is now toggled using the shared service.
This means, that every component has to communicate changes to the service only.
After that, each component is informed about changes and updates itself accordingly.
The update must not trigger new shared service calls as this would cause a loop!

This solves the following issue:
https://github.com/suga-data/MAK/issues/9